### PR TITLE
Update reif-atoms-interpret.md

### DIFF
--- a/reif-atoms-interpret.md
+++ b/reif-atoms-interpret.md
@@ -46,8 +46,7 @@ consisting of:
 3. A set `IA`, called the set of _reification atoms_ of `I`.
 4. A mapping `IS` from IRIs into `IR ⋃ IP`, called the _interpretation_ of IRIs.
 5. A partial mapping `IL` from _literal_ into `IR`, called the _interpretation_ of literals.
-6. A mapping `ID` from descriptors into `IA` called the _interpretation_ of descriptors.
-7. A mapping `IEXT` from `IP` into `2<sup>IR x IR</sup>`, called the _extension_ of properties.
+6. A mapping `IEXT` from `IP` into `2<sup>IR x IR</sup>`, called the _extension_ of properties.
 
 `A` is a mapping from `BlankNode` to `IR`.
 


### PR DESCRIPTION
you don't really need ID in the interpetation, as it is defined in terms of the other parts of the interpretation.

In fact, you *can't* include ID in the interpretation, as its definition depends on I *but also* on A:

ID(r) = ([I+A](r.s), [I+A](r.p), [I+A](r.o))